### PR TITLE
Update lyrics.R to handle instrumental songs

### DIFF
--- a/R/lyrics.R
+++ b/R/lyrics.R
@@ -98,6 +98,11 @@ scrape_lyrics_url <- function(song_lyrics_url, access_token=genius_token()) {
   # remove lines with square brackets
   lyrics <- lyrics[!stringr::str_detect(lyrics, pattern = "\\[|\\]")]
 
+  # error handling for instrumental songs, writes NA if there are no lyrics
+  if (is_empty(lyrics)) {
+    lyrics[1] <- NA
+  }
+
   # Convert to tibble
   lyrics <- tibble::tibble(line = lyrics)
 


### PR DESCRIPTION
This is an awesome package that makes it super easy to scrape data from genius.com! Thank you for your good work here. I ran into some trouble using it to get information from songs without lyrics, so I have a minor suggestion.

Previously, scrape_lyrics_url() would throw an error when it encountered an instrumental song. This checks to see if there are no lyrics left after removing items in square brackets, and if so, creates a single item with an NA value so that it can be converted to a tibble. This change resolved the error I was having with instrumental songs.

Thank you again! -John